### PR TITLE
CU-868degkma: Remove UniTask

### DIFF
--- a/Assets/MXRUS/Runtime/ISceneLoader.cs
+++ b/Assets/MXRUS/Runtime/ISceneLoader.cs
@@ -1,11 +1,11 @@
-﻿using Cysharp.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace MXRUS.SDK {
     /// <summary>
     /// Loads a .mxrus file
     /// </summary>
     public interface ISceneLoader {
-        UniTask<bool> Load(string sourceFilePath, string extractLocation);
+        Task<bool> Load(string sourceFilePath, string extractLocation);
         void Unload();
     }
 }

--- a/Assets/MXRUS/package.json
+++ b/Assets/MXRUS/package.json
@@ -10,7 +10,6 @@
 		"url": "https://www.managexr.com"
 	},
 	"dependencies": {
-		"com.unity.sharp-zip-lib": "1.3.8",
-		"com.cysharp.unitask": "2.2.5"
+		"com.unity.sharp-zip-lib": "1.3.8"
 	}
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "com.unity.sharp-zip-lib": "1.3.8",
-    "com.cysharp.unitask": "2.2.5",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.15",
     "com.unity.ide.vscode": "1.2.5",
@@ -40,15 +39,5 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  },
-  "scopedRegistries": [
-    {
-      "name": "OpenUPM",
-      "url": "https://package.openupm.com",
-      "scopes": [
-        "com.openupm",
-        "com.cysharp.unitask"
-      ]
-    }
-  ]
+  }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,12 +1,5 @@
 {
   "dependencies": {
-    "com.cysharp.unitask": {
-      "version": "2.2.5",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://package.openupm.com"
-    },
     "com.unity.ext.nunit": {
       "version": "1.0.6",
       "depth": 1,

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -20,29 +20,19 @@ MonoBehaviour:
     m_Url: https://packages.unity.com
     m_Scopes: []
     m_IsDefault: 1
-  - m_Id: scoped:OpenUPM
-    m_Name: OpenUPM
-    m_Url: https://package.openupm.com
-    m_Scopes:
-    - com.openupm
-    - com.cysharp.unitask
-    m_IsDefault: 0
   m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_ErrorMessage: 
     m_Original:
-      m_Id: scoped:OpenUPM
-      m_Name: OpenUPM
-      m_Url: https://package.openupm.com
-      m_Scopes:
-      - com.openupm
-      - com.cysharp.unitask
+      m_Id: 
+      m_Name: 
+      m_Url: 
+      m_Scopes: []
       m_IsDefault: 0
     m_Modified: 0
-    m_Name: OpenUPM
-    m_Url: https://package.openupm.com
+    m_Name: 
+    m_Url: 
     m_Scopes:
-    - com.openupm
-    - com.cysharp.unitask
+    - 
     m_SelectedScopeIndex: 0


### PR DESCRIPTION
SceneLoader.LoadAssetBundleAsync now uses AsyncOperation.completed to return the loaded AssetBundle. UniTask, which was previously being used to await the AsyncOperation has been removed.

allowSceneActivation is also no longer set to false. It is used with SceneManager.LoadSceneAsync when loading a scene, not an asset bundle.