### PR TITLE
CU-868degkma: Logo markers can now have default logos or make themselves invisible

### DIFF
--- a/Assets/MXRUS/Embeddings/Markers/ILogoMarker.cs
+++ b/Assets/MXRUS/Embeddings/Markers/ILogoMarker.cs
@@ -11,7 +11,15 @@ namespace MXRUS.SDK {
         LogoMarkerType LogoMarkerType { get; }
 
         /// <summary>
-        /// Sets the logo Texture2D on the object
+        /// The default logo shown when the logo set via <see cref="SetLogo(Texture2D)"/> is null
+        /// </summary>
+        Texture2D DefaultLogo { get; }
+
+        /// <summary>
+        /// Sets the logo Texture2D on the object.
+        /// If the passed texture is null
+        /// - <see cref="DefaultLogo"/> is shown, if available
+        /// - Otherwise the marker shows no logo
         /// </summary>
         /// <param name="texture"></param>
         void SetLogo(Texture2D texture);

--- a/Assets/MXRUS/Embeddings/Markers/MonoImageLogoMarker.cs
+++ b/Assets/MXRUS/Embeddings/Markers/MonoImageLogoMarker.cs
@@ -8,17 +8,34 @@ namespace MXRUS.SDK {
     [RequireComponent(typeof(Image))]
     public class MonoImageLogoMarker : MonoBehaviour, ILogoMarker {
         [SerializeField] LogoMarkerType _logoMarkerType;
+        [SerializeField] Sprite _defaultLogo;
 
         public LogoMarkerType LogoMarkerType => _logoMarkerType;
+
+        public Texture2D DefaultLogo => _defaultLogo == null ? null : _defaultLogo.texture;
 
         private Image _image;
 
         private void Awake() {
             _image = GetComponent<Image>();
+            SetLogo(DefaultLogo);
         }
 
         public void SetLogo(Texture2D texture) {
-            _image.sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), Vector2.one / 2);
+            if (texture != null) {
+                _image.sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), Vector2.one / 2);
+                _image.color = Color.white;
+            }
+            else {
+                if (DefaultLogo != null) {
+                    _image.sprite = Sprite.Create(DefaultLogo, new Rect(0, 0, DefaultLogo.width, DefaultLogo.height), Vector2.one / 2);
+                    _image.color = Color.white;
+                }
+                else {
+                    _image.sprite = null;
+                    _image.color = Color.clear;
+                }
+            }
         }
     }
 }

--- a/Assets/MXRUS/Embeddings/Markers/MonoRendererLogoMarker.cs
+++ b/Assets/MXRUS/Embeddings/Markers/MonoRendererLogoMarker.cs
@@ -7,17 +7,34 @@ namespace MXRUS.SDK {
     [RequireComponent(typeof(Renderer))]
     public class MonoRendererLogoMarker : MonoBehaviour, ILogoMarker {
         [SerializeField] LogoMarkerType _logoMarkerType;
+        [SerializeField] Texture2D _defaultLogo;
 
         public LogoMarkerType LogoMarkerType => _logoMarkerType;
 
+        public Texture2D DefaultLogo => _defaultLogo;
+
         private Renderer _renderer;
 
-        private void Awake () {
+        private void Awake() {
             _renderer = GetComponent<Renderer>();
+            SetLogo(DefaultLogo);
         }
 
         public void SetLogo(Texture2D texture) {
-            _renderer.material.mainTexture = texture;
+            if (texture != null) {
+                _renderer.material.mainTexture = texture;
+                _renderer.material.color = Color.white;
+            }
+            else {
+                if (DefaultLogo != null) {
+                    _renderer.material.mainTexture = DefaultLogo;
+                    _renderer.material.color = Color.white;
+                }
+                else {
+                    _renderer.material.mainTexture = null;
+                    _renderer.material.color = Color.clear;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Texture2D ILogoMarker.DefaultLogo allows setting a default logo to logo markers.

If setting logo to null:
- If a default logo is present, it is shown
- Otherwise the marker is hidden