### PR TITLE
UnsupportedShader violation no longer prevents export

### DIFF
--- a/Assets/MXRUS/Editor/SceneExportValidator.cs
+++ b/Assets/MXRUS/Editor/SceneExportValidator.cs
@@ -88,8 +88,11 @@ namespace MXRUS.SDK.Editor {
                 });
             return unsupportedMaterials.Select(x => new SceneExportViolation(
                 SceneExportViolation.Types.UnsupportedShader,
-                true,
-                "Only default URP, Unlit, UI, Sprites and Skybox shaders are supported.",
+                false,
+                "URP, Unlit, UI, Sprites, Skybox and official ManageXR shaders are recommended. " +
+                "Other shaders may not run as expected.\n" +
+                "Use them only if really required to achieve certain visuals and verify the results before deploying." +
+                "These shaders may also increase the export size and they often can be replaced with the recommended ones.",
                 x)).ToList();
         }
 


### PR DESCRIPTION
The shaders get packaged in the asset bundles. This violation is now a warning instead of an error that prevents export. The description has been updated to provide more information.