### PR TITLE
Support loading renamed mxrus files

### DIFF
--- a/Assets/MXRUS/Editor/SceneExporter.cs
+++ b/Assets/MXRUS/Editor/SceneExporter.cs
@@ -14,6 +14,7 @@ namespace MXRUS.SDK.Editor {
 
         private const string ASSETS_ASSETBUNDLE_NAME = "assets";
         private const string SCENE_ASSETBUNDLE_NAME = "scene";
+        private const string UNITY_GENERATED_ASSET_BUNDLE_EXT = ".unitygenerated";
         
         private const string BUILD_REPORT_FILE_NAME = "build_report.txt";
         private const string FAILED_BUILD_REPORT_FILE_NAME = "failed_mxrus_build_report.txt";
@@ -68,6 +69,11 @@ namespace MXRUS.SDK.Editor {
 
             // Write the build report inside the export directory
             File.WriteAllText(Path.Combine(exportDir, BUILD_REPORT_FILE_NAME), buildReport.ToPrettyString());
+
+            // Add a custom extension to the unity generated asset bundle
+            // The name of this asset bundle is the same as the mxrus file being exported, but with no extension
+            var generatedAssetBundlePath = Path.Combine(exportDir, Path.GetFileNameWithoutExtension(outputFilePath));
+            File.Move(generatedAssetBundlePath, generatedAssetBundlePath + UNITY_GENERATED_ASSET_BUNDLE_EXT);
 
             // Compress export directory to the output file path
             ICompressionUtility zipCompression = new SharpZipLibCompressionUtility();

--- a/Assets/MXRUS/Runtime/ISceneLoader.cs
+++ b/Assets/MXRUS/Runtime/ISceneLoader.cs
@@ -28,7 +28,7 @@ namespace MXRUS.SDK {
         /// <param name="sourceFilePath">Path to the mxrus file to load</param>
         /// <param name="extractLocation">Directory used to extract the mxrus file temporarily</param>
         /// <returns></returns>
-        Task<bool> Load(string sourceFilePath, string extractLocation);
+        Task<bool> Load(string sourceFilePath, string extractLocation = null);
 
         /// <summary>
         /// Unloads the AssetBundles of an mxrus file that may have been loaded previously.

--- a/Assets/MXRUS/Runtime/SceneLoader.cs
+++ b/Assets/MXRUS/Runtime/SceneLoader.cs
@@ -4,14 +4,16 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 
 using UnityEngine;
+using System.Linq;
 
 namespace MXRUS.SDK {
     public class SceneLoader : ISceneLoader {
         private const string TAG = "SceneLoader";
         private const string ASSETS_ASSETBUNDLE_NAME = "assets";
         private const string SCENE_ASSETBUNDLE_NAME = "scene";
+        private const string UNITY_GENERATED_ASSET_BUNDLE_EXT = ".unitygenerated";
         private const string TEMP_EXTRACT_DIRNAME_POSTFIX = "-extract";
-        
+
         private readonly Dictionary<string, AssetBundle> _bundles = new Dictionary<string, AssetBundle>();
 
         /// <summary>
@@ -88,7 +90,11 @@ namespace MXRUS.SDK {
             compressionUtility.ExtractToDirectory(sourceFilePath, extractDirPath);
 
             // Attempt to load the bundles from the extract directory
-            var bundleNames = new string[] { ASSETS_ASSETBUNDLE_NAME, SCENE_ASSETBUNDLE_NAME, fileNameWithoutExt };
+            var bundleNames = new string[] { 
+                ASSETS_ASSETBUNDLE_NAME, 
+                SCENE_ASSETBUNDLE_NAME, 
+                GetUnityGeneratedBundleName(extractDirPath)
+            };
             Debug.unityLogger.Log(LogType.Log, TAG, $"Attempting to load the following asset bundles: {string.Join(", ", bundleNames)}");
 
             List<string> failedBundleNames = new List<string>();
@@ -146,6 +152,14 @@ namespace MXRUS.SDK {
                 }
             };
             return source.Task;
+        }
+
+        // Unity generates an additional asset bundle when we export the mxrus file
+        // During export, this file is renamed to have a custom extension that can be used
+        // to find it.
+        private string GetUnityGeneratedBundleName(string directoryPath) {
+            return Directory.GetFiles(directoryPath, "*", SearchOption.TopDirectoryOnly)
+                .First(x => Path.GetExtension(x).Equals(UNITY_GENERATED_ASSET_BUNDLE_EXT));
         }
     }
 }


### PR DESCRIPTION
Previously the SceneLoader assumed that the Unity generated asset bundle inside the mxrus file was named the same as the mxrus file itself.

However, this prevents the loader from loading mxrus files after they have been renamed.

The unity generated bundle now has a ".unitygenerated" extension that makes it easier to find it even if the mxrus file has been renamed.