### PR TITLE
Add scene name violation

### DIFF
--- a/Assets/MXRUS/Editor/SceneExportValidator.cs
+++ b/Assets/MXRUS/Editor/SceneExportValidator.cs
@@ -31,6 +31,10 @@ namespace MXRUS.SDK.Editor {
 
             violations.AddRange(GetAudioListenerViolations());
 
+            var sceneNameViolations = GetSceneNameViolation();
+            if (sceneNameViolations != null)
+                violations.Add(sceneNameViolations);
+
             return violations;
         }
 
@@ -214,6 +218,26 @@ namespace MXRUS.SDK.Editor {
                     x
                 ))
                 .ToList();
+            }
+            return null;
+        }
+
+        private SceneExportViolation GetSceneNameViolation() {
+            List<string> reservedNames = new List<string> {
+                "Launcher",
+                "Video",
+                "OculusQuest",
+                "Pico",
+                "Wave"
+            };
+
+            var activeScene = SceneManager.GetActiveScene();
+            if(reservedNames.Contains(activeScene.name)) {
+                return new SceneExportViolation(
+                    SceneExportViolation.Types.SceneNameViolation,
+                    true,
+                    $"The scene name not allowed. The following names are prohibited: {string.Join(", ", reservedNames)}"
+                );
             }
             return null;
         }

--- a/Assets/MXRUS/Editor/SceneExportViolation.cs
+++ b/Assets/MXRUS/Editor/SceneExportViolation.cs
@@ -52,9 +52,14 @@ namespace MXRUS.SDK.Editor {
             MultipleUserAreaProvidersFound,
 
             /// <summary>
-            /// if the scene has an AudioListener 
+            /// If the scene has an AudioListener 
             /// </summary>
-            AudioListenerFound
+            AudioListenerFound,
+
+            /// <summary>
+            /// Whether the scene name is allowed.
+            /// </summary>
+            SceneNameViolation
         }
 
         /// <summary>
@@ -77,7 +82,7 @@ namespace MXRUS.SDK.Editor {
         /// </summary>
         public Object Object { get; private set; }
 
-        public SceneExportViolation(Types type, bool preventsExport, string description, Object obj) {
+        public SceneExportViolation(Types type, bool preventsExport, string description, Object obj = null) {
             Type = type;
             PreventsExport = preventsExport;
             Description = description;


### PR DESCRIPTION
User exported scenes cannot have the same names as the ones we have in the Homescreen. Since the Unity scene APIs are heavily reliant on scene names, this would create conflicts. These include Launcher, Video, OculusQuest, Pico and Wave.