### PR TITLE
Better direction visuals of the MonoCircularUserAreaProvider avatar

### DIFF
--- a/Assets/MXRUS/Embeddings/GizmosX.cs
+++ b/Assets/MXRUS/Embeddings/GizmosX.cs
@@ -26,5 +26,27 @@ namespace MXRUS.SDK {
                 prevPoint = nextPoint;
             }
         }
+
+        public static void DrawSectorXZ(Vector3 center, Vector3 direction, float angle, int arcSegments, float radius) {
+            float dirAngle = Mathf.Atan2(direction.z, direction.x) * Mathf.Rad2Deg;
+            float halfAngle = angle * 0.5f;
+            float angleStep = angle / arcSegments;
+
+            // First spoke
+            float startAngle = dirAngle - halfAngle;
+            Vector3 prevPoint = center + new Vector3(Mathf.Cos(startAngle * Mathf.Deg2Rad), 0, Mathf.Sin(startAngle * Mathf.Deg2Rad)) * radius;
+            Gizmos.DrawLine(center, prevPoint);
+
+            // Arc edges and remaining spokes
+            for (int i = 1; i <= arcSegments; i++) {
+                float currentAngle = startAngle + angleStep * i;
+                Vector3 nextPoint = center + new Vector3(Mathf.Cos(currentAngle * Mathf.Deg2Rad), 0, Mathf.Sin(currentAngle * Mathf.Deg2Rad)) * radius;
+
+                Gizmos.DrawLine(prevPoint, nextPoint);
+                Gizmos.DrawLine(center, nextPoint);
+
+                prevPoint = nextPoint;
+            }
+        }
     }
 }

--- a/Assets/MXRUS/Embeddings/Providers/MonoCircularUserAreaProvider.cs
+++ b/Assets/MXRUS/Embeddings/Providers/MonoCircularUserAreaProvider.cs
@@ -49,10 +49,9 @@ namespace MXRUS.SDK {
             Gizmos.color = Color.yellow;
             GizmosX.DrawConcentricCirclesXZ(Vector3.zero, walkableRadius, PERIMETER_SEGMENTS, RING_COUNT);
 
-            // Draw lines to show forward and right directions relative to the avatars rotation
-            Gizmos.color = Color.white;
-            Gizmos.DrawLine(Vector3.zero, Vector3.forward * 2);
-            Gizmos.DrawLine(Vector3.zero, Vector3.right * 2);
+            // Draw a sector in the direction of the avatar
+            Gizmos.color = Color.green;
+            GizmosX.DrawSectorXZ(Vector3.zero, Vector3.forward, 90, 10, walkableRadius);
 
             // Draw avatar body
             Gizmos.color = Color.cyan;
@@ -66,6 +65,13 @@ namespace MXRUS.SDK {
                 new Vector3(ARM_LENGTH, ARM_WIDTH, ARM_WIDTH)
             );
             Gizmos.DrawSphere(Vector3.up * BODY_HEIGHT + (transform.up * HEAD_RADIUS), HEAD_RADIUS);
+
+            // Draw a VR headset
+            Gizmos.color = new Color(.4f, .4f, 1);
+            Gizmos.DrawCube(
+                (Vector3.up * (BODY_HEIGHT + HEAD_RADIUS * 1.25f)) + (.66f * HEAD_RADIUS * Vector3.forward),
+                new Vector3(HEAD_RADIUS * 1.5f, HEAD_RADIUS * .5f, HEAD_RADIUS)
+            );
 
             // Reset Gizmos class
             Gizmos.color = Color.white;


### PR DESCRIPTION
Gizmos added to display the following:
- a blue VR headset on the avatar head
- a green colored 90 degree sector in the forward direction