### PR TITLE
CU-868fbqk0h: Add Auto Resolve button to SceneExportWindow

### DIFF
--- a/Assets/MXRUS/Editor/SceneExportViolation.cs
+++ b/Assets/MXRUS/Editor/SceneExportViolation.cs
@@ -1,4 +1,8 @@
-﻿using UnityEngine;
+﻿using System;
+
+using UnityEngine;
+
+using Object = UnityEngine.Object;
 
 namespace MXRUS.SDK.Editor {
     internal class SceneExportViolation {
@@ -73,6 +77,18 @@ namespace MXRUS.SDK.Editor {
         public bool PreventsExport { get; private set; }
 
         /// <summary>
+        /// Whether this violation can be automatically resolved
+        /// by the scene export window
+        /// </summary>
+        public bool CanBeAutoResolved { get; private set; }
+
+        /// <summary>
+        /// The confirmation message to be shown when the user
+        /// attempts to auto resolve this violation.
+        /// </summary>
+        public string AutoResolveConfirmationMessage { get; private set; }
+
+        /// <summary>
         /// Description of the violation
         /// </summary>
         public string Description { get; private set; }
@@ -82,11 +98,26 @@ namespace MXRUS.SDK.Editor {
         /// </summary>
         public Object Object { get; private set; }
 
+        private Action<Object> _resolveMethod;
+
         public SceneExportViolation(Types type, bool preventsExport, string description, Object obj = null) {
             Type = type;
             PreventsExport = preventsExport;
             Description = description;
             Object = obj;
+        }
+
+        public SceneExportViolation SetAutoResolver(string message, Action<Object> resolveMethod) {
+            AutoResolveConfirmationMessage = message;
+            CanBeAutoResolved = true;
+            _resolveMethod = resolveMethod;
+            return this;
+        }
+
+        public void AutoResolve() {
+            if (CanBeAutoResolved) {
+                _resolveMethod?.Invoke(Object);
+            }
         }
     }
 }

--- a/Assets/MXRUS/Editor/SceneExportWindow.cs
+++ b/Assets/MXRUS/Editor/SceneExportWindow.cs
@@ -207,13 +207,38 @@ namespace MXRUS.SDK.Editor {
 
                 var preventsExport = first.PreventsExport;
                 var description = first.Description;
+                var canBeAutoResolved = first.CanBeAutoResolved;
 
-                _foldoutStates[i] = EditorGUILayout.Foldout(
-                    _foldoutStates[i],
-                    $"{_violationTypes[i]} {(preventsExport ? " (Error)" : " (Warning)")}",
-                    true,
-                    preventsExport ? _errorFoldoutStyle : _warningFoldoutStyle
-                );
+                // Show the violation type with the Auto Resolve button, if applicable for this violation type
+                EditorGUILayout.BeginHorizontal();
+                {
+                    _foldoutStates[i] = EditorGUILayout.Foldout(
+                        _foldoutStates[i],
+                        $"{_violationTypes[i]} {(preventsExport ? " (Error)" : " (Warning)")}",
+                        true,
+                        preventsExport ? _errorFoldoutStyle : _warningFoldoutStyle
+                    );
+                    if (canBeAutoResolved) {
+                        GUILayout.Label("");
+                        if (GUILayout.Button("Auto Resolve")) {
+                            var accepted = EditorUtility.DisplayDialog(
+                                "Auto Resolving",
+                                first.AutoResolveConfirmationMessage + "\n\nDo you want to proceed?",
+                                "OK"
+                            );
+                            if (accepted) {
+                                foreach (var violationToResolve in violations) {
+                                    violationToResolve.AutoResolve();
+                                }
+                                Validate();
+                                EditorGUILayout.EndHorizontal();
+                                return;
+                            }
+                        }
+                    }
+                }
+                EditorGUILayout.EndHorizontal();
+
                 EditorGUILayout.Space(10);
 
                 if (!_foldoutStates[i]) continue;


### PR DESCRIPTION
Pressing the button and confirming the message that follows will automatically resolve the following issues:
- CustomScriptFound by removing the script from the gameobject
- CameraFound by deleting camera gameobjects
- AudioListenerFound by deleting the AudioListener component
- EventSystemFound by deleting event system gameobjects
- NoUserAreaProviderFound by creating a new gameobject and attaching MonoCircularUserAreaProvider component to it

All the above changes are undoable using Ctrl+Z.